### PR TITLE
Point to stable charmcraft channel

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,4 +24,4 @@ jobs:
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           charm-path: ./
-          charmcraft-channel: latest/edge
+          charmcraft-channel: latest/stable


### PR DESCRIPTION
The publish action previously pointed to edge as we needed 1.4, but this version is now in the stable channel so we don't have to point to edge anymore.