### PR TITLE
Change application name to spark-k8s

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-name: spark
+name: spark-k8s
 display-name: Apache Spark
 summary: Unified analytics engine for large-scale data processing
 description: https://spark.apache.org/


### PR DESCRIPTION
Charmcraft looks for the `name` field in `metadata.yaml` this was previously `spark` and now has been changed to `spark-k8s` to match the name registered in charmhub.