### PR TITLE
Make examples useable with README proposed config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ Upstream documentation can be found at https://github.com/GoogleCloudPlatform/sp
 ## Usage
 
 The Spark Operator may be deployed using the Juju command line as follows
+
 ```bash
-juju deploy spark-k8s
+juju deploy spark-k8s spark
 ```
+
+The service account will be created with the name of the spark application. To
+conveniently use upstream examples keep the application name as `spark`.
 
 ## Looking for a fully supported platform for MLOps?
 

--- a/examples/spark-pi.yaml
+++ b/examples/spark-pi.yaml
@@ -37,7 +37,7 @@ spec:
     memory: "512m"
     labels:
       version: 3.1.1
-    serviceAccount: spark-k8s
+    serviceAccount: spark
     volumeMounts:
       - name: "test-volume"
         mountPath: "/tmp"

--- a/examples/spark-pi.yaml
+++ b/examples/spark-pi.yaml
@@ -37,7 +37,7 @@ spec:
     memory: "512m"
     labels:
       version: 3.1.1
-    serviceAccount: spark
+    serviceAccount: spark-k8s
     volumeMounts:
       - name: "test-volume"
         mountPath: "/tmp"


### PR DESCRIPTION
The example's service account was changed to the spark-k8s.

Closes: https://github.com/canonical/spark-operator/issues/17