### PR TITLE
cannon/change-2d837069

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Release charm to channel
-        uses: canonical/charming-actions/release-charm@1.0.3
+uses: canonical/charming-actions/release-charm@2.0.0-rc
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changes applied by commit-cannon:
  * Replaced line `uses: canonical/charming-actions/release-charm@1.0.3` with `uses: canonical/charming-actions/release-charm@2.0.0-rc` in `.github/workflows/release.yaml`
